### PR TITLE
TEOS-10 support

### DIFF
--- a/examples/TEOS-10 example.ipynb
+++ b/examples/TEOS-10 example.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CO2sys with TEOS-10 support\n",
+    "\n",
+    "In 2010, new definitions, Conservative Temperature (Tcsv) and Absolute Salinity (SA), became the new adopted standard in oceanography for temperature and salinity. \n",
+    "\n",
+    "CO2sys software, until now, accepted only in-situ temperature and practical salinity as input. CO2sys software has been extended to implement new oceanographic standards for ocean temperature and salinity (Thermodynamic Equation of Seawater, TEOS-10).\n",
+    "\n",
+    "#### The aim of this notebook is to show how to use this extension through several examples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## A two step procedure\n",
+    "Due to ascendant compatibility requirements, TEOS support has not been deeply integrated into CO2SYS. Instead, we chose to provide only a set of conversion routines in Matlab.\n",
+    "\n",
+    "When using TEOS-10 temperature and salinity, a two step procedure is required from user's program:\n",
+    "1. call conversion routines for temperature and salinity input\n",
+    "2. call the main CO2sys routine (unchanged) with converted input"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Salinity conversion\n",
+    "\n",
+    "For salinity conversion, there exist two different methods:\n",
+    "\n",
+    "1. When chemical composition is not known\n",
+    "salinity conversion is based on temperature, salinity, sea water pressure and geographic location (given by latitude and longitude). Geographic location is used to infer sea water chemical composition based on ocean climatology.\n",
+    "\n",
+    "2. When chemical composition is known\n",
+    "salinity conversion is based on temperature, salinity, sea water pressure, total alkalinity, dissolved inorganic carbon, and nitrate and silicate concentrations\n",
+    "\n",
+    "The first example will illustrate the case when chemical concentrations are not known but geographic location is. The second example will illustrate the second case.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Input parameters\n",
+    "The following values will be used as input throughout the exemples in this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "% Input parameters\n",
+    "TAlk = 2300;        % µmol/kg\n",
+    "DIC = 2000;\n",
+    "SA = 35;            % Absolute Salinity\n",
+    "CsvTin = 18;        % Convervative temperature at input conditions\n",
+    "Pin = 0;            % Pressure at input conditions\n",
+    "\n",
+    "% Nutrient concentration\n",
+    "TSil = 60;           % Total Silicate (µmol/kg)\n",
+    "TPhos = 2;           % Total Phosphate (µmol/kg)\n",
+    "\n",
+    "% prevent specific warning message\n",
+    "warning (\"off\", \"Matlab-style short-circuit operation performed for operator &\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1st example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1st step: conversion from TEOS-10 to EOS-80\n",
+    "Salinity conversion depends on depth (pressure) and geographic location: If location is not given, an arbitrary location is chosen: the mid equatorial atlantic ocean. <br> Note that this implies an error on computed SA ranging from 0 up to 0.02 g/kg\n",
+    "\n",
+    "Temperature conversion depends on pressure only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ans = geographic location : North Atlantic\n",
+      "Tin =  18.004\n",
+      "SP =  34.836\n"
+     ]
+    }
+   ],
+   "source": [
+    "% the following function call converts\n",
+    "%    - Temperature :  from Conservative to in-situ \n",
+    "%    - Salinity    :  from Absolute (g/kg) to Practical (psu)\n",
+    "\n",
+    "# Example when longitude and latitude are known\n",
+    "long = -10;    # degrees East\n",
+    "lat = 45;      # degrees North\n",
+    "[Tin, SP] = teos2eos_geo(SA, CsvTin, Pin, long, lat);\n",
+    "\"geographic location : North Atlantic\"\n",
+    "Tin\n",
+    "SP\n",
+    "\n",
+    "# Example when longitude and latitude are NOT known\n",
+    "# \"geographic location : unknown\"\n",
+    "# [Tin, SP] = teos2eos_geo(SA, CTin, Pin, [], []);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### 2nd step: CO2sys computation with converted S and T\n",
+    "In this step, we just call CO2SYS() routine as usually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ans = \n",
+      "{\n",
+      "  [1,1] = TAlk\n",
+      "  [2,1] = TCO2\n",
+      "  [3,1] = pHin\n",
+      "  [4,1] = pCO2in\n",
+      "  [5,1] = fCO2in\n",
+      "  [6,1] = HCO3in\n",
+      "  [7,1] = CO3in\n",
+      "  [8,1] = CO2in\n",
+      "}\n",
+      "ans =\n",
+      "\n",
+      " Columns 1 through 6:\n",
+      "\n",
+      "   2300.0000   2000.0000      8.1470    302.5164    301.4646   1782.1221\n",
+      "\n",
+      " Columns 7 and 8:\n",
+      "\n",
+      "    207.5333     10.3446\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "[DATA,HEADERS] = CO2SYS(TAlk,DIC,1,2,SP,Tin,0,Pin,0,TSil,TPhos,1,10,1);\n",
+    "HEADERS(1:8)\n",
+    "DATA(1:8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2nd example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1st step: Alternative conversion from TEOS-10 to EOS-80\n",
+    "This conversion depends on chemical composition of seawater: alcalinity, carbon, nitrate and silicate. Note that the nitrate concentration may be inferred from the Phosphate concentration, using Redfield ratio."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tin =  18.004\n",
+      "SP =  34.831\n"
+     ]
+    }
+   ],
+   "source": [
+    "% Nitrate: one may use Redfield ratio and Phosphate concentration\n",
+    "NH3 = TPhos * 16;\n",
+    "[Tin, SP] = teos2eos_chem(SA, CsvTin, Pin, TAlk, DIC, NH3, TSil);\n",
+    "Tin\n",
+    "SP"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### 2nd step: CO2sys computation with converted S and T\n",
+    "In this step, we just call CO2SYS() routine as usually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ans = \n",
+      "{\n",
+      "  [1,1] = TAlk\n",
+      "  [2,1] = TCO2\n",
+      "  [3,1] = pHin\n",
+      "  [4,1] = pCO2in\n",
+      "  [5,1] = fCO2in\n",
+      "  [6,1] = HCO3in\n",
+      "  [7,1] = CO3in\n",
+      "  [8,1] = CO2in\n",
+      "}\n",
+      "ans =\n",
+      "\n",
+      " Columns 1 through 6:\n",
+      "\n",
+      "   2300.0000   2000.0000      8.1471    302.4809    301.4292   1782.1181\n",
+      "\n",
+      " Columns 7 and 8:\n",
+      "\n",
+      "    207.5383     10.3436\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "[DATA,HEADERS] = CO2SYS(TAlk,DIC,1,2,SP,Tin,0,Pin,0,TSil,TPhos,1,10,1);\n",
+    "HEADERS(1:8)\n",
+    "DATA(1:8)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Octave",
+   "language": "octave",
+   "name": "octave"
+  },
+  "language_info": {
+   "file_extension": ".m",
+   "help_links": [
+    {
+     "text": "GNU Octave",
+     "url": "https://www.gnu.org/software/octave/support.html"
+    },
+    {
+     "text": "Octave Kernel",
+     "url": "https://github.com/Calysto/octave_kernel"
+    },
+    {
+     "text": "MetaKernel Magics",
+     "url": "https://github.com/calysto/metakernel/blob/master/metakernel/magics/README.md"
+    }
+   ],
+   "mimetype": "text/x-octave",
+   "name": "octave",
+   "version": "4.0.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/errorsExample1.m
+++ b/examples/errorsExample1.m
@@ -1,0 +1,40 @@
+% Test of num_deriv() with scalar input
+function result = test_errors ()
+    PAR1 = 2300;    % Alk
+    PAR2 = 2000;    % DIC
+    PAR1TYPE = 1;
+    PAR2TYPE = 2;
+    SAL = 35;
+    TEMPIN = 18;
+    TEMPOUT = 2; 
+    PRESIN = 0;
+    PRESOUT = PRESIN;
+    SI = 60;
+    PO4 = 2;
+    pHSCALEIN = 1;   % total scale
+    K1K2CONSTANTS = 10; % Lueker 2000
+    KSO4CONSTANTS = 1;  % KSO4 of Dickson & TB of Uppstrom 1979
+
+    ePAR1 = 2;    % Alk
+    ePAR2 = 2;    % DIC
+    eSAL = 0;
+    eTEMP = 0;
+    eSI = 4;
+    ePO4 = 0.1;
+ 
+    % With no errors on Ks
+    epK=0;
+    result = errors (PAR1,PAR2,PAR1TYPE,PAR2TYPE,SAL,TEMPIN,TEMPOUT,PRESIN,PRESOUT,SI,PO4,...
+                     ePAR1,ePAR2,eSAL,eTEMP,eSI,ePO4,epK,0,pHSCALEIN,K1K2CONSTANTS,KSO4CONSTANTS)
+
+    % With default errors on Ks
+    epK = '';
+    result = errors (PAR1,PAR2,PAR1TYPE,PAR2TYPE,SAL,TEMPIN,TEMPOUT,PRESIN,PRESOUT,SI,PO4,...
+                     ePAR1,ePAR2,eSAL,eTEMP,eSI,ePO4,epK,0,pHSCALEIN,K1K2CONSTANTS,KSO4CONSTANTS)
+
+    % With default errors on Ks and some correlation between input pairs
+    epK = '';
+    result = errors (PAR1,PAR2,PAR1TYPE,PAR2TYPE,SAL,TEMPIN,TEMPOUT,PRESIN,PRESOUT,SI,PO4,...
+                     ePAR1,ePAR2,eSAL,eTEMP,eSI,ePO4,epK,0.02, pHSCALEIN,K1K2CONSTANTS,KSO4CONSTANTS);
+end
+

--- a/src/CO2SYS.m
+++ b/src/CO2SYS.m
@@ -8,7 +8,7 @@ function [DATA,HEADERS,NICEHEADERS]=CO2SYS(PAR1,PAR2,PAR1TYPE,PAR2TYPE,SAL,TEMPI
 % CO2SYS calculates and returns the state of the carbonate system of 
 %    oceanographic water samples, if supplied with enough input.
 %
-% Please note that his software is intended to be exactly identical to the 
+% Please note that this software is intended to be exactly identical to the 
 %    DOS and Excel versions that have been released previously, meaning that
 %    results obtained should be very nearly indentical for identical input.
 % Additionally, several of the dissociation constants K1 and K2 that have 
@@ -211,7 +211,11 @@ function [DATA,HEADERS,NICEHEADERS]=CO2SYS(PAR1,PAR2,PAR1TYPE,PAR2TYPE,SAL,TEMPI
 % 
 %**************************************************************************
 %
-% This is version 1.1 (uploaded to CDIAC at SEP XXth, 2011):
+% This is version 2.0 (availlable on GitHub)
+%
+% **** Changes since 2.0
+%	- slight changes to allow error propagation
+%	- new option to choose K1 & K2 from Waters et al. (2014): fixes inconsistencies with Millero (2010) identified by Orr et al. (2015)
 %
 % **** Changes since 1.01 (uploaded to CDIAC at June 11th, 2009):
 % - Function cleans up its global variables when done (if you loose variables, this may be the cause -- see around line 570)

--- a/src/eos2teos_chem.m
+++ b/src/eos2teos_chem.m
@@ -1,0 +1,66 @@
+function [CT, SA] = eos2teos_chem(SP, T, P, TA, DIC, NO3, SIOH4)
+% eos2teos_chem.Rd
+% Convert temperature and salinity from EOS-80 to TEOS-10
+% 
+% Description:
+%      Convert in-situ to Conservative temperature and Practical (SP) to
+%      Absolute Salinity (SA) Salinity conversion depends on Total
+%      Alkalinity, Dissolved Inorganic Carbon and Nitrate and Silicate
+%      concentrations.
+% 
+% Usage:
+%      [CT, SA] = eos2teos_chem(SP, T, P, TA, DIC, NO3, SIOH4)
+%      
+% Input:
+%       SP: Practical Salinity on the practical salinity scale
+%        T: in-situ temperature in deg. C
+%        P: Sea water pressure in dbar
+%       TA: Total Alkalinity, in µmol/kg
+%      DIC: Dissolved Inorganic Carbone concentration in µmol/kg
+%      NO3: Total Nitrate concentration in µmol/kg
+%    SIOH4: Total Silicate concentration in µmol/kg
+% 
+% Details:
+%      Conversion from Practical (SP) to Absolute Salinity (SA) depends
+%      on carbon system parameters and ion concentration which most
+%      affect water density anomalies.
+% 
+% Output:
+%       CT: Conservative Temperature (deg C)
+%       SA: Absolute Salinity (g/kg)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      R. Pawlowicz, D. G. Wright, and F. J. Millero, 2011: The
+%      effects of biogeochemical processes on oceanic conductivity/
+%      salinity/density relationships and the characterization of real
+%      seawater
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      teos2eos_chem does the reverse, eos2teos_geo, sp2sa_chem
+%      package GSW for Matlab
+% 
+% Examples:
+%         % Calculate Conservative Temperature and Absolute Salinity of a sample with 
+%         % Practical Salinity of 35 psu, in-situ Temperature of 18 deg C,
+%         % at 0 dbar and Total Alkalinity of 0.00234 mol/kg and DIC of 0.00202 mol/kg
+%         % zero Nitrate and Silicate
+%         [CT, SA] = eos2teos_chem(35, 18, 0, 0.00234, 0.00202, 0, 0)
+%      
+
+    % convert salinity
+    SA = sp2sa_chem (SP, TA, DIC, NO3, SIOH4);
+    % convert temperature
+    CT = gsw_CT_from_t (SA, T, P);
+end

--- a/src/eos2teos_geo.m
+++ b/src/eos2teos_geo.m
@@ -1,0 +1,60 @@
+function [CT, SA] = eos2teos_geo(SP, T, P, long, lat)
+% eos2teos_geo:        Convert temperature and salinity from EOS-80 to TEOS-10
+% 
+% Description:
+%      Convert in-situ to Conservative temperature and Practical (SP) to
+%      Absolute Salinity (SA) Salinity conversion depends on depth and
+%      geographic location.
+% 
+% Usage:
+%      [CT, SA] = eos2teos_geo(SP, T, P, long, lat)
+%      
+% Input:
+%       SP: Practical Salinity on the practical salinity scale
+%        T: in-situ temperature in deg. C
+%        P: Sea water pressure in dbar
+%     long: Longitude in decimal degrees [ 0 ... +360 ] or [ -180 ...
+%           +180 ]
+%      lat: latitude in decimal degrees [-90 ... 90]
+% 
+% Details:
+%      Conversion from Practical (SP) to Absolute Salinity (SA) depends
+%      on water density anomaly which is correlated with Silicate
+%      concentration. This function relies on silicate concentration
+%      taken from WOA (World Ocean Atlas) to evaluate density anomaly.
+% 
+% Output:
+%       CT: Conservative Temperature (deg C)
+%       SA: Absolute Salinity (g/kg)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      teos2eos_geo does the reverse, eos2teos_chem, sp2sa_geo
+%      package GSW for Matlab
+% 
+% Examples:
+%         % Calculate Conservative Temperature and Absolute Salinity of a sample with 
+%         % Practical Salinity of 35 psu, in-situ Temperature of 18 deg C,
+%         % depth is 10 dbar and location is 188 degrees East and 4 degrees North.
+%         [CT, SA] = eos2teos_geo(35, 18, 10, 188, 4)
+% 
+    if (isempty(lat) || isempty(long))
+        lat = 0; long = -25;
+    end
+    % convert salinity
+    SA = gsw_SA_from_SP(SP, P, long, lat);
+    % convert temperature
+    CT = gsw_CT_from_t (SA, T, P);
+end

--- a/src/sa2sp_chem.m
+++ b/src/sa2sp_chem.m
@@ -1,0 +1,74 @@
+function SP = sa2sp_chem(SA, TA, DIC, NO3, SIOH4)
+% sa2sp_chem:             From Absolute to Practical Salinity
+% 
+% Description:
+%      Convert from Absolute (SA) to Practical Salinity (SP) based on
+%      Total Alkalinity, Dissolved Inorganic Carbon and Nitrate and
+%      Silicate concentrations.
+% 
+% Usage:
+%      sa2sp_chem(SA, TA, DIC, NO3, SIOH4)
+%      
+% Input:
+%       SA: Absolute Salinity in g/kg
+%       TA: Total Alkalinity, in µmol/kg
+%      DIC: Dissolved Inorganic Carbone concentration in µmol/kg
+%      NO3: Total Nitrate concentration in µmol/kg
+%    SIOH4: Total Silicate concentration in µmol/kg
+% 
+% Details:
+%      Convert from Absolute (SA) to Practical Salinity (SP) from carbon
+%      system parameters and ion concentration which most affect water
+%      density anomalies.
+% 
+% Output:
+%       SP: Practical Salinity (in psu)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      R. Pawlowicz, D. G. Wright, and F. J. Millero, 2011: The
+%      effects of biogeochemical processes on oceanic conductivity/
+%      salinity/density relationships and the characterization of real
+%      seawater
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      sp2sa_chem does the reverse
+%      sa2sp_geo
+% 
+% Examples:
+%         % Calculate the practical salinity of a sample with Absolute Salinity of 35 g/kg,
+%         % Total Alkalinity of 0.00234 mol/kg, DIC of 0.00202 mol/kg, zero Nitrate and Silicate
+%         SP = sa2sp_chem(35, 2340, 0.2020, 0, 0)
+%      
+
+    % Reverse conversion (SA from SP) follows this equation :
+    %  SP = 1/r * (SA - sa_anomaly)
+    %    with
+    %        r = 35.16504 / 35
+    %  SP = 1/r * (SA - 55.6e-6 * (TA - x*SP) - 4.7e-6 * (DIC - y*SP) - nutrients)
+    %    with
+    %       x  = 2300 / 35
+    %       y  = 2080 / 35
+    %       nutrients = 38.9e-6 * NO3 + 50.7e-6 * SIOH4
+    %
+    %  SP * (1 - 55.6e-6 * x/r - 4.7e-6 * y/r) = 1/r * (SA - 55.6e-6 * TA - 4.7e-6 * DIC - nutrients)
+    %
+    %  SP * (1 - 55.6e-6 * 2300 / 35.16504 - 4.7e-6 * 2080 / 35.16504) = ....
+    %
+    %  SP * 0.9960854303 = 1/r * (SA - 55.6e-6 * TA - 4.7e-6 * DIC - nutrients)
+    %
+    %  SP = 0.999218211671 * (SA - 55.6e-6 * TA - 4.7e-6 * DIC - nutrients)
+
+    SP = 0.999218211671 * (SA - 55.6e-6 * TA - 4.7e-6 * DIC - 38.9e-6 * NO3 - 50.7e-6 * SIOH4);
+end

--- a/src/sa2sp_geo.m
+++ b/src/sa2sp_geo.m
@@ -1,0 +1,56 @@
+function SP = sa2sp_geo(SA, P, long, lat)
+% sa2sp_geo:         From Absolute to Practical Salinity
+% 
+% Description:
+%      Convert from Absolute (SA) to Practical Salinity (SP) based on
+%      depth and geographic location.
+% 
+% Usage:
+%      sa2sp_geo(SA, P, long, lat)
+%      
+% Input:
+%       SA: Absolute Salinity in g/kg
+%        P: Sea water pressure in dbar
+%     long: Longitude in decimal degrees [ 0 ... +360 ] or [ -180 ... +180 ]
+%      lat: latitude in decimal degrees [-90 ... 90]
+% 
+% Details:
+%      This subroutine is almost an alias of subroutine gsw_SP_from_SA
+%      from gsw package on which it relies. The only difference is in
+%      that depth and location are optional.  If location is not given,
+%      or incomplete (either longitude or latitude missing), an arbitrary
+%      location is chosen: the mid equatorial atlantic ocean. Note that
+%      this implies an error on computed SA ranging from 0 up to 0.02
+%      g/kg
+% 
+% Output:
+%       SP: Practical Salinity (psu)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      sp2sa_geo does the reverse
+%      sa2sp_chem
+% 
+% Examples:
+%         % Calculate the practical salinity of a sample whose absolute Salinity is 35,
+%         % depth is 10 dbar and location is 188 degrees East and 4 degrees North.
+%         SP = sa2sp_geo(35, 10, 188, 4)
+%      
+
+    if (isempty(lat) || isempty(long))
+        lat = 0; long = -25;
+    end
+    SP = gsw_SP_from_SA(SA,P,long,lat);
+end

--- a/src/sp2sa_chem.m
+++ b/src/sp2sa_chem.m
@@ -1,0 +1,70 @@
+function SA = sp2sa_chem(SP, TA, DIC, NO3, SIOH4)
+% sp2sa_chem :           From Practical to Absolute Salinity
+% 
+% Description:
+%      Convert from Practical (SP) to Absolute Salinity (SA) based on
+%      Total Alkalinity, Dissolved Inorganic Carbon and Nitrate and
+%      Silicate concentrations.
+% 
+% Usage:
+%      sp2sa_chem(SP, TA, DIC, NO3, SIOH4)
+%      
+% Input:
+%       SP: Practical Salinity on the practical salinity scale
+%       TA: Total Alkalinity, in µmol/kg
+%      DIC: Dissolved Inorganic Carbone concentration in µmol/kg
+%      NO3: Total Nitrate concentration in µmol/kg
+%    SIOH4: Total Silicate concentration in µmol/kg
+% 
+% Details:
+%      Convert from Practical (SP) to Absolute Salinity (SA) from carbon
+%      system parameters and ion concentration which most affect water
+%      density anomalies.
+% 
+% Output:
+%       SA: Absolute Salinity (g/kg)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      R. Pawlowicz, D. G. Wright, and F. J. Millero, 2011: The
+%      effects of biogeochemical processes on oceanic conductivity/
+%      salinity/density relationships and the characterization of real
+%      seawater
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      sa2sp_chem does the reverse
+%      sp2sa_geo
+% 
+% Examples:
+%         % Calculate the absolute salinity of a sample with practical Salinity of 35,
+%         % Total Alkalinity of 0.00234 mol/kg and DIC of 0.00202 mol/kg
+%         SA = sp2sa_chem(SP=35, TA=0.00234, DIC=0.00202)
+%
+
+
+    % This function is made of two parts :
+    %   1) conversion from Practical to Reference Salinity (major part)
+    %   2) conversion from Reference to Absolute Salinity (Absolute Anomaly, minor part)
+    %
+
+    % DIC and TA values of standard sea water
+    TA_stdsw  = 2300 * SP /35;
+    DIC_stdsw = 2080 * SP /35;
+    
+    % Absolute salinity anomaly (g/kg)
+    sal_anomaly = 55.6e-6 * (TA - TA_stdsw) + 4.7e-6 * (DIC - DIC_stdsw) + 38.9e-6 * NO3 + 50.7e-6 * SIOH4;
+    
+    SR = SP * 35.16504 / 35;
+    SA = SR + sal_anomaly;
+end

--- a/src/sp2sa_geo.m
+++ b/src/sp2sa_geo.m
@@ -1,0 +1,55 @@
+function SA = sp2sa_geo(SP, P, long, lat)
+% sp2sa_geo:         From Practical to Absolute Salinity
+% 
+% Description:
+%      Convert from Practical (SP) to Absolute Salinity (SA) based on
+%      depth and geographic location.
+% 
+% Usage:
+%      sp2sa_geo(SP, P, long, lat)
+%      
+% Input:
+%       SP: Practical Salinity on the practical salinity scale
+%        P: Sea water pressure in dbar
+%     long: Longitude in decimal degrees [ 0 ... +360 ] or [ -180 ... +180 ]
+%      lat: latitude in decimal degrees [-90 ... 90]
+% 
+% Details:
+%      This subroutine is almost an alias of subroutine gsw_SA_from_SP of
+%      gsw package on which it relies. The only difference is in that
+%      depth and location are optional.  If location is not given, or
+%      incomplete (either longitude or latitude missing), an arbitrary
+%      location is chosen: the mid equatorial atlantic ocean. Note that
+%      this implies an error on computed SA ranging from 0 up to 0.02
+%      g/kg
+% 
+% Output:
+%       SA: Absolute Salinity (g/kg)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      sa2sp_geo does the reverse
+%      sp2sa_chem
+% 
+% Examples:
+%         % Calculate the absolute salinity of a sample whose practical Salinity is 35,
+%         % depth is 10 dbar and location is 188 degrees East and 4 degrees North.
+%         SA = sp2sa_geo(35, 10, 188, 4)
+
+    if (isempty(lat) || isempty(long))
+        lat = 0; long = -25;
+    end
+    SA = gsw_SA_from_SP(SP,P,long,lat);
+end

--- a/src/teos2eos_chem.m
+++ b/src/teos2eos_chem.m
@@ -1,0 +1,66 @@
+function [T, SP] = teos2eos_chem(SA, CT, P, TA, DIC, NO3, SIOH4)
+% teos2eos_chem:      Convert temperature and salinity from TEOS-10 to EOS-80
+% 
+% Description:
+%      Convert conservative temperature to in-situ temperature and
+%      Absolute Salinity (SA) to Practical Salinity (SP). Salinity
+%      conversion depends on Total Alkalinity, Dissolved Inorganic Carbon
+%      and Nitrate and Silicate concentrations.
+% 
+% Usage:
+%      [T, SP] = teos2eos_chem(SA, CT, P, TA, DIC, NO3, SIOH4)
+%      
+% Input:
+%       SA: Absolute Salinity in g/kg
+%       CT: Conservative Temperature in degrees C
+%        P: Sea water pressure in dbar
+%       TA: Total Alkalinity, in µmol/kg
+%      DIC: Dissolved Inorganic Carbone concentration in µmol/kg
+%      NO3: Total Nitrate concentration in µmol/kg
+%    SIOH4: Total Silicate concentration in µmol/kg
+% 
+% Details:
+%      Conversion from Absolute (SA) to Practical Salinity (SP) depends
+%      on carbon system parameters and ion concentration which most
+%      affect water density anomalies.
+% 
+% Output:
+%        T: in situ Temperature (deg C)
+%       SP: Practical Salinity (psu)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      R. Pawlowicz, D. G. Wright, and F. J. Millero, 2011: The
+%      effects of biogeochemical processes on oceanic conductivity/
+%      salinity/density relationships and the characterization of real
+%      seawater
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      eos2teos_chem does the reverse, teos2eos_geo, sa2sp_cham
+%      package GSW for Matlab
+% 
+% Examples:
+%         % Calculate insitu Temperature and practical salinity of a sample with 
+%         % Absolute Salinity of 35 g/kg, Conservative Temperature of 18 deg C,
+%         % at 0 dbar and Total Alkalinity of 0.00234 mol/kg and DIC of 0.00202 mol/kg, 
+%         % zero Nitrate and Silicate
+%         [T, SP] = teos2eos_chem(35, 18, 0, 0.00234, 0.00202, 0, 0)
+%      
+
+    % convert temperature
+    T = gsw_t_from_CT (SA, CT, P);
+    % convert salinity
+    SP = sa2sp_chem (SA, TA, DIC, NO3, SIOH4);
+end
+

--- a/src/teos2eos_geo.m
+++ b/src/teos2eos_geo.m
@@ -1,0 +1,61 @@
+function [T, SP] = teos2eos_geo(SA, CT, P, long, lat)
+% teos2eos_geo:       Convert temperature and salinity from TEOS-10 to EOS-80
+% 
+% Description:
+%      Convert conservative temperature to in-situ temperature and
+%      Absolute Salinity (SA) to Practical Salinity (SP). Salinity
+%      conversion depends on depth and geographic location.
+% 
+% Usage:
+%      [T, SP] = teos2eos_geo(SA, CT, P, long, lat)
+%      
+% Input:
+%       SA: Absolute Salinity in g/kg
+%       CT: Conservative Temperature in degrees C
+%        P: Sea water pressure in dbar
+%     long: Longitude in decimal degrees [ 0 ... +360 ] or [ -180 ...
+%           +180 ]
+%      lat: latitude in decimal degrees [-90 ... 90]
+% 
+% Details:
+%      Conversion from Absolute (SA) to Practical Salinity (SP) depends
+%      on water density anomaly which is correlated with Silicate
+%      concentration. This function relies on silicate concentration
+%      taken from WOA (World Ocean Atlas) to evaluate density anomaly.
+% 
+% Output:
+%        T: in situ Temperature (deg C)
+%       SP: Practical Salinity (psu)
+% 
+% Author(s):
+%      Jean-Marie Epitalon
+% 
+% References:
+%      TEOS-10 web site: http://www.teos-10.org/
+% 
+%      What every oceanographer needs to know about TEOS-10 (The TEOS-10
+%      Primer) by Rich Pawlowicz (on TEOS-10 web site)
+% 
+%      T. J. McDougall, D. R. Jackett, F. J. Millero, R. Pawlowicz, 
+%      and P. M. Barker, 2012: Algorithm for estimating
+%      Absolute Salinity
+% 
+% See Also:
+%      eos2teos_geo does the reverse, teos2eos_chem, sa2sp_geo
+%      package GSW for Matlab
+% 
+% Examples:
+%         % Calculate insitu Temperature and practical salinity of a sample with 
+%         % Absolute Salinity of 35 g/kg, Conservative Temperature of 18 deg C,
+%         % depth is 10 dbar and location is 188 degrees East and 4 degrees North.
+%         [T, SP] = teos2eos_geo(35, 18, 10, 188, 4)
+%      
+
+    if (isempty(lat) || isempty(long))
+        lat = 0; long = -25;
+    end
+    % convert temperature
+    T = gsw_t_from_CT (SA, CT, P);
+    % convert salinity
+    SP = gsw_SP_from_SA(SA, P, long, lat);
+end


### PR DESCRIPTION
I added one source file for each conversion routine: eos2teos_geo, eos2teos_chem, teos2eos_geo, teos2eos_chem, sa2sp_chem, sa2sp_geo, sp2sa_chem, sp2sa_geo 
help and usage help are in the comment header in each file.
I also added example files in the "example" subfolder. The example for TEOS support is a iPython notebook.

Notes: 
- GSW-matlab must be downloaded and its intall location added to the Matlab search path.
This is done through the command addpath().
- CO2sys is compatible with Octave as well as Matlab
- GSW is not fully compatible for now. If one wants a Octave-compatible version, one must take it from GitHub